### PR TITLE
Update build.gradle - Change Java version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,11 +33,12 @@ android {
     compileSdk 34
 
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
+
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = '17'
     }
 
     sourceSets {


### PR DESCRIPTION
```
Execution failed for task ':video_compress:compileDebugKotlin'.
 'compileDebugJavaWithJavac' task (current target is 1.8) and 'compileDebugKotlin' task (current target is 17) jvm target compatibility should be set to the same Java version.
```